### PR TITLE
added an option to delay the scan when scan result is empty

### DIFF
--- a/options.go
+++ b/options.go
@@ -65,6 +65,14 @@ func WithScanInterval(d time.Duration) Option {
 	}
 }
 
+// Option to enable idle scan
+func WithIdleScan(idleScanInterval time.Duration) Option {
+	return func(c *Consumer) {
+		c.isIdleScanEnabled = true
+		c.idleScanInterval = idleScanInterval
+	}
+}
+
 // WithMaxRecords overrides the maximum number of records to be
 // returned in a single GetRecords call for the consumer (specify a
 // value of up to 10,000)


### PR DESCRIPTION
Refactor Consumer to optionally enable idle scan functionality to dynamically choose whether they need idle scanning behavior (e.g., for longer wait periods during idle times) and configure it as needed.

- Added `WithIdleScan` option to allow users to enable idle scan with a custom interval.
- Default behavior disables idle scan unless explicitly enabled via `WithIdleScan`.
